### PR TITLE
use mite-reminder as a sub-command of mite-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,26 @@
 # mite-reminder
 command line tool to check if times are entered for each day in mite
 
+## Setup
+
+### Install & configure mite-cli
+
+A fork of mite-cli can be installed via:
+
 ```
-npm intall
-MITE_API_KEY=<your api key> npm start
+npm i -g phiros/mite-cli
+```
+
+The api key for mite & the account need to be configured via:
+
+```
+mite config set apiKey <YOUR MITE API KEY HERE>
+mite config set account leanovate
+```
+
+**NOTE:** Your API key can be retrieved at https://leanovate.mite.yo.lk/myself
+
+### Install mite-reminder
+```
+npm i -g 'leanovate/mite-reminder#use-mite-reminder-as-subcommand-of-mite-cli'
 ```

--- a/index.js
+++ b/index.js
@@ -1,18 +1,22 @@
+#!/usr/bin/env node
 const miteApi = require("mite-api")
 const prompts = require("prompts");
 const moment = require("./moment-holiday-berlin.min"); // compiled with https://github.com/kodie/moment-holiday
 const { createMiteApi } = require("./mite/mite-api")
 const { isWeekend} = require("./mite/time")
+const config = require("./mite/config")
 
-if (!process.env.MITE_API_KEY) {
-    console.error("MITE_API_KEY environment variable not set.\n")
-    console.log("Either run 'export MITE_API_KEY=<your key>'")
-    console.log("or run again with 'MITE_API_KEY=<your key> npm start'")
-    console.log("Your api key can be found here: https://leanovate.mite.yo.lk/myself")
+const API_KEY = config.get().apiKey
+const ACCOUNT_NAME = config.get().account 
+
+if (!!!API_KEY) {
+    console.error("Mite key is not set!")
+    console.error("Please set the key via the 'mite' command")
+    console.error("Your api key can be found here: https://<account>.mite.yo.lk/myself where account is the name of the organization")
     process.exit()
 }
 
-const mite = createMiteApi(process.env.MITE_API_KEY)
+const mite = createMiteApi(API_KEY)
 
 const referenceDay = moment().subtract(15, "day") // referer to the previous month until the 15th
 const startOfMonth = referenceDay.clone().startOf("month")
@@ -55,7 +59,7 @@ const runTimeEntries = () => mite.getTimeEntries({
                 console.log("aborting...")
                 break // breaking because the user did not select yes or no (likely Ctrl+C)
             } else if (didWork) {
-                console.log(`Your times are missing, please update them here: https://leanovate.mite.yo.lk/#${date.format("YYYY/MM/DD")}`)
+                console.log(`Your times are missing, please update them here: https://${ACCOUNT_NAME}.mite.yo.lk/#${date.format("YYYY/MM/DD")}`)
             } else {
                 await createNonProjectEntry(dateAsString)
                 console.log("Ok, I've marked that day a non-project time")

--- a/mite/config.js
+++ b/mite/config.js
@@ -1,0 +1,12 @@
+const nconf = require('nconf');
+const path = require('path');
+const os = require('os');
+
+const homedir = os.homedir();
+const configFilename = path.resolve(path.join(homedir, '.mite-cli.json'));
+
+nconf.file(configFilename);
+
+nconf.defaults({});
+
+module.exports = nconf;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,11 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
     "asn1": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
@@ -73,10 +78,30 @@
         }
       }
     },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "combined-stream": {
       "version": "0.0.7",
@@ -123,6 +148,11 @@
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "delayed-stream": {
       "version": "0.0.5",
@@ -228,6 +258,24 @@
         "ctype": "0.5.2"
       }
     },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -281,6 +329,14 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.1.tgz",
       "integrity": "sha512-P3kRv+B+Ra070ng2VKQqW4qW7gd/v3iD8sy/zOdcYRsfiD+QBokQNOps/AfP6Hr48cBhIIBFWckB9aO+IZhrWg=="
     },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
+    },
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
@@ -318,6 +374,24 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
       "integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA=="
     },
+    "nconf": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
+      "integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
+      "requires": {
+        "async": "^1.4.0",
+        "ini": "^1.3.0",
+        "secure-keys": "^1.0.0",
+        "yargs": "^3.19.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        }
+      }
+    },
     "node-cron": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-2.0.3.tgz",
@@ -331,6 +405,11 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
       "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oauth-sign": {
       "version": "0.3.0",
@@ -346,6 +425,14 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
       "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "requires": {
+        "lcid": "^1.0.0"
+      }
     },
     "performance-now": {
       "version": "2.1.0",
@@ -404,6 +491,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "secure-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
+      "integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
     },
     "sisteransi": {
       "version": "1.0.0",
@@ -576,6 +668,24 @@
         }
       }
     },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
     "tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -647,6 +757,20 @@
       "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.18.tgz",
       "integrity": "sha512-7QGozxlOhour77BCQbbyW5XFP8ioIz/DPK67IyO3DnJtF0WXrXueMwqrYFM9yqyfgENcyxL+vktz2oJeZfdWtw=="
     },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      }
+    },
     "ws": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
@@ -660,6 +784,25 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/ws-heartbeat/-/ws-heartbeat-1.0.4.tgz",
       "integrity": "sha512-OFr46ds6+OAXDdt9JXb7mA+xgNg1XN0qhrM5CmnbvTL2vx8jsgspUYSR75OKqkmM8s4R8aJ2AHhm7webf7RfOw=="
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yargs": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+      "requires": {
+        "camelcase": "^2.0.1",
+        "cliui": "^3.0.3",
+        "decamelize": "^1.1.1",
+        "os-locale": "^1.4.0",
+        "string-width": "^1.0.1",
+        "window-size": "^0.1.4",
+        "y18n": "^3.2.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,13 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "bin": {
+    "mite-reminder": "index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/leanovate/mite-reminder.git"
+  },
   "scripts": {
     "start": "node index.js",
     "bot": "node ./bot/bot.js"
@@ -12,6 +19,7 @@
   "dependencies": {
     "mite-api": "^0.1.0",
     "moment": "^2.23.0",
+    "nconf": "^0.10.0",
     "node-cron": "^2.0.3",
     "prompts": "^2.0.1",
     "slackbots": "^1.2.0"


### PR DESCRIPTION
Allows mite-reminder to be used as a sub-command of mite-cli.
It can be called by either:

```
$ mite-reminder
```
or

```
$ mite reminder
```

Note that in the second case the mite command notices that it does not support the `reminder` sub-command and tries to recover from this by executing the command `mite-reminder`. This is similar to how git can be extended. 
Also note that mite-reminder and mite now share one common config file which allows a user to configure both the api key and the account (aka organization)